### PR TITLE
feat: add metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,6 +805,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +872,9 @@ dependencies = [
  "hex",
  "home",
  "http",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "metrics-util",
  "prost",
  "prost-types",
  "rand 0.9.2",
@@ -898,6 +910,12 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "energon"
@@ -1451,6 +1469,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,6 +1582,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "metrics"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dea7ac8057892855ec285c440160265225438c3c45072613c25a4b26e98ef5"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b166dea96003ee2531cf14833efedced545751d800f03535801d833313f8c15"
+dependencies = [
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "indexmap 2.7.1",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 2.0.11",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe8db7a05415d0f919ffb905afa37784f71901c9a773188876984b4f769ab986"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.2",
+ "indexmap 2.7.1",
+ "metrics",
+ "ordered-float",
+ "quanta",
+ "radix_trie",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,6 +1662,15 @@ name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -1669,6 +1752,15 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "overload"
@@ -1790,6 +1882,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,6 +1974,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,6 +2002,16 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"
@@ -1956,6 +2079,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2252,6 +2393,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ tokio-util = { version = "0.7.13", features = ["rt"] }
 arc-swap = "1.7.1"
 rusqlite = "0.37.0"
 rand = "0.9.1"
+metrics-exporter-prometheus = { version = "0.17.2", default-features = false, features = [
+    "http-listener",
+] }
+metrics = "0.24.2"
+metrics-util = "0.20.0"
 
 [build-dependencies]
 tonic-build = "0.12.3"

--- a/src/chain/epoch.rs
+++ b/src/chain/epoch.rs
@@ -1,6 +1,7 @@
 use super::handler::ChainError;
 use crate::key::node::Node;
 use crate::key::Scheme;
+use crate::net::metrics::GroupMetrics;
 use crate::net::utils::Address;
 use crate::protobuf::drand::PartialBeaconPacket;
 
@@ -30,10 +31,15 @@ impl<S: Scheme> EpochNode<S> {
 pub struct EpochConfig<S: Scheme> {
     share: dkg::DistKeyShare<S>,
     remote_nodes: Vec<EpochNode<S>>,
+    group_metrics: GroupMetrics,
 }
 
 impl<S: Scheme> EpochConfig<S> {
-    pub fn new(nodes: Vec<Node<S>>, share: dkg::DistKeyShare<S>) -> Self {
+    pub fn new(
+        nodes: Vec<Node<S>>,
+        share: dkg::DistKeyShare<S>,
+        group_metrics: GroupMetrics,
+    ) -> Self {
         let poly = PubPoly {
             commits: share.commitments().to_vec(),
         };
@@ -52,6 +58,7 @@ impl<S: Scheme> EpochConfig<S> {
         Self {
             share,
             remote_nodes,
+            group_metrics,
         }
     }
 
@@ -89,7 +96,7 @@ impl<S: Scheme> EpochConfig<S> {
         self.share.pri_share.index()
     }
 
-    pub fn thr(&self) -> usize {
-        self.share.commits.len()
+    pub fn metrics_for_group(&self) -> GroupMetrics {
+        self.group_metrics
     }
 }

--- a/src/chain/time.rs
+++ b/src/chain/time.rs
@@ -49,8 +49,9 @@ pub fn time_of_round(period: u32, genesis: u64, round: u64) -> u64 {
 
 /// Returns time discrepancy for given round.
 pub fn round_discrepancy_ms(period: Seconds, genesis_time: u64, round: u64) -> u128 {
-    let expected = u128::from(time_of_round(period.get_value(), genesis_time, round)) * 1000;
-    time_now().as_millis() - expected
+    let time_now_ms = time_now().as_millis();
+    let round_time_ms = u128::from(time_of_round(period.get_value(), genesis_time, round)) * 1000;
+    time_now_ms - round_time_ms
 }
 
 /// Returns current Unix time as duration.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -56,6 +56,9 @@ pub struct Config {
     /// Set the listening (binding) address of the private API. Useful if you have some kind of proxy.
     #[arg(long)]
     pub private_listen: String,
+    /// Launch a metrics server at the specified host:port.
+    #[arg(long, default_value = None)]
+    pub metrics: Option<String>,
     /// Indicates the id for the randomness generation process which will be started
     #[arg(long, default_value = None)]
     pub id: Option<String>,
@@ -248,6 +251,12 @@ fn keygen<S: Scheme>(config: &KeyGenConfig) -> Result<()> {
 async fn start_cmd(config: Config) -> Result<()> {
     let private_listen = Address::precheck(&config.private_listen)?;
     let control_port = config.control.clone();
+
+    // Start metrics server
+    if let Some(ref address) = config.metrics {
+        crate::net::metrics::setup_metrics(address)?;
+    }
+
     let daemon = Daemon::new(config)?;
     // Start control server
     let control = daemon.tracker.spawn({

--- a/src/core/beacon.rs
+++ b/src/core/beacon.rs
@@ -70,10 +70,11 @@ impl BeaconID {
         self.0.as_bytes()
     }
 
+    #[inline(always)]
     pub fn as_str(&self) -> &'static str {
         self.0
     }
-
+    #[inline(always)]
     pub fn is_eq(&self, other_id: &str) -> bool {
         self.0 == other_id
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #![warn(clippy::pedantic)]
-#![allow(clippy::unreadable_literal)]
+#![allow(clippy::unreadable_literal, clippy::inline_always)]
 mod chain;
 mod cli;
 mod core;

--- a/src/net/metrics.rs
+++ b/src/net/metrics.rs
@@ -1,0 +1,100 @@
+//! This module provides API to setup and report metrics.
+use crate::core::beacon::BeaconID;
+use crate::net::utils::Address;
+
+use anyhow::bail;
+use metrics::{describe_gauge, gauge};
+use metrics_exporter_prometheus::PrometheusBuilder;
+use metrics_util::MetricKindMask;
+
+use std::net::SocketAddr;
+use std::str::FromStr;
+use std::time::Duration;
+
+pub fn setup_metrics(address: &str) -> anyhow::Result<()> {
+    let address = Address::precheck(address)?;
+
+    let builder = PrometheusBuilder::new();
+    if let Err(err) = builder
+        .idle_timeout(
+            MetricKindMask::COUNTER | MetricKindMask::HISTOGRAM | MetricKindMask::GAUGE,
+            Some(Duration::from_secs(35)),
+        )
+        .with_http_listener(SocketAddr::from_str(address.as_str())?)
+        .install()
+    {
+        bail!("failed to install Prometheus: {err}")
+    }
+
+    // Note: Keep same descriptions for same metrics with Drand-go.
+
+    describe_gauge!(
+        "beacon_discrepancy_latency",
+        "Discrepancy between beacon creation time and calculated round time"
+    );
+
+    describe_gauge!("last_beacon_round", "Last locally stored beacon");
+
+    describe_gauge!("group_size", "Number of peers in the current group");
+
+    describe_gauge!(
+        "group_threshold",
+        "Number of shares needed for beacon reconstruction"
+    );
+
+    Ok(())
+}
+
+#[inline(always)]
+/// Discrepancy between beacon creation time and calculated round time.
+fn beacon_discrepancy_latency(id: BeaconID, value: f64) {
+    gauge!("beacon_discrepancy_latency", "beacon_id" => id.as_str()).set(value);
+}
+
+#[inline(always)]
+/// Last locally stored beacon.
+fn last_beacon_round(id: BeaconID, value: f64) {
+    gauge!("last_beacon_round", "beacon_id" => id.as_str()).set(value);
+}
+
+#[inline(always)]
+/// Number of shares needed for beacon reconstruction.
+fn group_threshold(id: BeaconID, value: f64) {
+    gauge!("group_threshold", "beacon_id" => id.as_str()).set(value);
+}
+
+#[inline(always)]
+/// Number of peers in the current group.
+fn group_size(id: BeaconID, value: f64) {
+    gauge!("group_size", "beacon_id" => id.as_str()).set(value);
+}
+
+/// Helper to report metrics once recovered or synced beacon is saved sussecfully to persistent storage.
+pub fn report_metrics_on_put(
+    id: BeaconID,
+    discrepancy: u128,
+    last_round: u64,
+    group_metrics: GroupMetrics,
+) {
+    beacon_discrepancy_latency(id, discrepancy as f64);
+    last_beacon_round(id, last_round as f64);
+    group_threshold(id, group_metrics.thr);
+    group_size(id, group_metrics.group_size);
+}
+
+#[derive(Default, Clone, Copy)]
+/// Group metrics are same within an epoch, so we cast them *once* into
+/// required `f64` representation to avoid repeated conversions.
+pub struct GroupMetrics {
+    group_size: f64,
+    thr: f64,
+}
+
+impl GroupMetrics {
+    pub fn new(group_size: usize, group_threshold: u32) -> Self {
+        Self {
+            group_size: group_size as f64,
+            thr: f64::from(group_threshold),
+        }
+    }
+}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2,6 +2,8 @@ pub mod control;
 pub mod dkg_control;
 pub mod dkg_public;
 pub mod health;
+#[allow(clippy::cast_precision_loss)]
+pub mod metrics;
 pub mod pool;
 pub mod protocol;
 pub mod public;

--- a/src/test_with_golang/utils.rs
+++ b/src/test_with_golang/utils.rs
@@ -712,6 +712,7 @@ impl NodeConfig {
                     private_listen: self.private_listen.clone(),
                     // Load all ids.
                     id: None,
+                    metrics: None,
                 };
                 tokio::task::spawn(async move { Cli::start(config).run().await.unwrap() });
             }


### PR DESCRIPTION
Metrics are reported in the same fashion as in Drand-go.
- beacon_discrepancy_latency
- last_beacon_round
- group_threshold
- group_size