### PR TITLE
chore: remove unused pedersen-bls-unchained scheme

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         backend: ["blstrs", "arkworks"]
-        scheme: ["pedersen-bls-chained", "pedersen-bls-unchained", "bls-unchained-g1-rfc9380", "bls-bn254-unchained-on-g1"]
+        scheme: ["pedersen-bls-chained", "bls-unchained-g1-rfc9380", "bls-bn254-unchained-on-g1"]
     steps:
       - uses: actions/checkout@v2
       - name: Install protobuf-compiler
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         backend: ["blstrs", "arkworks"]
-        scheme: ["pedersen-bls-chained", "pedersen-bls-unchained", "bls-unchained-g1-rfc9380", "bls-bn254-unchained-on-g1"]
+        scheme: ["pedersen-bls-chained", "bls-unchained-g1-rfc9380", "bls-bn254-unchained-on-g1"]
     steps:
       - uses: actions/checkout@v2
       - name: Install protobuf-compiler
@@ -97,7 +97,7 @@ jobs:
       fail-fast: false
       matrix:
         backend: ["blstrs", "arkworks"]
-        scheme: ["pedersen-bls-chained", "pedersen-bls-unchained", "bls-unchained-g1-rfc9380", "bls-bn254-unchained-on-g1"]
+        scheme: ["pedersen-bls-chained", "bls-unchained-g1-rfc9380", "bls-bn254-unchained-on-g1"]
     steps:
       - uses: actions/checkout@v2
       - name: Install protobuf-compiler

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@ use crate::{
 use anyhow::{bail, Result};
 use clap::{arg, command, Parser, Subcommand};
 use energon::{
-    drand::schemes::{BN254UnchainedOnG1Scheme, DefaultScheme, SigsOnG1Scheme, UnchainedScheme},
+    drand::schemes::{BN254UnchainedOnG1Scheme, DefaultScheme, SigsOnG1Scheme},
     points::KeyPoint,
     traits::Affine,
 };
@@ -238,7 +238,6 @@ async fn generate_keypair(config: KeyGenConfig) -> Result<()> {
     println!("Generating private / public key pair");
     match config.scheme.as_str() {
         DefaultScheme::ID => keygen::<DefaultScheme>(&config)?,
-        UnchainedScheme::ID => keygen::<UnchainedScheme>(&config)?,
         SigsOnG1Scheme::ID => keygen::<SigsOnG1Scheme>(&config)?,
         BN254UnchainedOnG1Scheme::ID => keygen::<BN254UnchainedOnG1Scheme>(&config)?,
         _ => bail!("keygen: unknown scheme: {}", config.scheme),
@@ -414,7 +413,6 @@ async fn check_identity_address(peer: &Address, beacon_id: String) -> Result<()>
     if match resp.scheme_name.as_str() {
         DefaultScheme::ID => KeyPoint::<DefaultScheme>::deserialize(&resp.key).is_err(),
         SigsOnG1Scheme::ID => KeyPoint::<SigsOnG1Scheme>::deserialize(&resp.key).is_err(),
-        UnchainedScheme::ID => KeyPoint::<UnchainedScheme>::deserialize(&resp.key).is_err(),
         BN254UnchainedOnG1Scheme::ID => {
             KeyPoint::<BN254UnchainedOnG1Scheme>::deserialize(&resp.key).is_err()
         }

--- a/src/core/multibeacon.rs
+++ b/src/core/multibeacon.rs
@@ -10,9 +10,7 @@ use crate::{
     net::{pool::PoolSender, protocol::PartialMsg},
 };
 use arc_swap::{ArcSwap, ArcSwapAny, Guard};
-use energon::drand::schemes::{
-    BN254UnchainedOnG1Scheme, DefaultScheme, SigsOnG1Scheme, UnchainedScheme,
-};
+use energon::drand::schemes::{BN254UnchainedOnG1Scheme, DefaultScheme, SigsOnG1Scheme};
 use std::{path::PathBuf, sync::Arc};
 use tokio::sync::mpsc;
 
@@ -59,9 +57,6 @@ impl BeaconHandler {
         let handler = match scheme {
             DefaultScheme::ID => {
                 BeaconProcess::<DefaultScheme>::run(fs, pair, pool, private_listen)?
-            }
-            UnchainedScheme::ID => {
-                BeaconProcess::<UnchainedScheme>::run(fs, pair, pool, private_listen)?
             }
             SigsOnG1Scheme::ID => {
                 BeaconProcess::<SigsOnG1Scheme>::run(fs, pair, pool, private_listen)?

--- a/src/test_with_golang/chain.rs
+++ b/src/test_with_golang/chain.rs
@@ -6,7 +6,7 @@ use crate::{
     protobuf::drand::ChainInfoPacket,
 };
 use energon::drand::{
-    schemes::{BN254UnchainedOnG1Scheme, DefaultScheme, SigsOnG1Scheme, UnchainedScheme},
+    schemes::{BN254UnchainedOnG1Scheme, DefaultScheme, SigsOnG1Scheme},
     traits::DrandScheme,
 };
 use std::time::Duration;
@@ -145,10 +145,6 @@ async fn sync() {
         },
         DefaultScheme::ID => {
             let group:Group<DefaultScheme> = Toml::toml_decode(&group_str.parse().unwrap()).unwrap();
-            (group.transition_time, group.genesis_time)
-        }
-        UnchainedScheme::ID => {
-            let group:Group<UnchainedScheme> = Toml::toml_decode(&group_str.parse().unwrap()).unwrap();
             (group.transition_time, group.genesis_time)
         }
         BN254UnchainedOnG1Scheme::ID => {


### PR DESCRIPTION
1. The scheme is not used by LoE.
2. Application is generic over schemes.